### PR TITLE
MatplotlibDeprecationWarning

### DIFF
--- a/oscillator.py
+++ b/oscillator.py
@@ -148,7 +148,7 @@ class FigureWidget(QtGui.QWidget):
         """ Create enough subplots to hold `num_plots` plots. """
         self.canDraw = False
         self.fig.clear()
-        self.axes = [self.fig.add_subplot(1,num_plots,n)
+        self.axes = [self.fig.add_subplot(1,num_plots,n+1)
                      for n in range(num_plots)]
         self.lines = [ax.plot(numpy.zeros(1024))[0] for ax in self.axes]
         for ax in self.axes:


### PR DESCRIPTION
The use of 0 (which ends up being the _last_ sub-plot) is deprecated in 1.4 and will raise an error in 1.5 mplDeprecation)
